### PR TITLE
Fix highlighting raw strings also with 'r'

### DIFF
--- a/RON.sublime-syntax
+++ b/RON.sublime-syntax
@@ -4,6 +4,9 @@ name: RON
 file_extensions:
   - ron
 scope: source.ron
+variables: # from RustEnhanced
+  non_raw_ident: '[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+'
+  identifier: '(?:(?:(?:r\#)?{{non_raw_ident}})\b)' # include a word boundary at the end to ensure all possible characters are consumed, to prevent catastrophic backtracking
 contexts:
   main:
     - include: extension
@@ -106,7 +109,7 @@ contexts:
         - match: '\)'
           scope: punctuation.section.dictionary.end.ron
           pop: true
-        - match: '[a-z_][A-Za-z_0-9]*'
+        - match: '[a-z_][A-Za-z_0-9]*(?!#")'
           scope: entity.name.tag.ron
         - match: '\:'
           scope: punctuation.separator.dictionary.key-value.ron
@@ -154,22 +157,42 @@ contexts:
       scope: constant.character.escape.ron
     - match: \\.
       scope: invalid.illegal.unrecognized-string-escape.ron
-  raw_string:
-    - match: 'r'
-    - include: raw_string_inner
-  raw_string_inner:
-    - match: '(#*)"'
+  format-raw-string: # from RustEnhanced
+    - match: (r)(#*)"
       captures:
-        1: punctuation.definition.string.begin.ron
+        1: storage.type.string.ron
+        2: punctuation.definition.string.begin.ron
       push:
-      - meta_scope: string.quoted.double.ron
-      - match: '"\1'
-        scope: punctuation.definition.string.end.ron
-        pop: true
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.raw.ron
+        - match     : '"\2'
+          scope     : punctuation.definition.string.end.ron
+          pop       : true
+        - include   : format-escapes
+  format-escapes:
+    - match: '\{\{|\}\}'
+      scope: constant.character.escape.ron
+    - match: |-
+        (?x)                      # Spec from http://doc.rust-lang.org/std/fmt/
+        \{
+          (\d+|{{identifier}})?
+          (
+            :                     # format_spec delimiter
+            (.?[<>^])?            # [[fill]align]
+            [+-]?                 # [sign]
+            \#?                   # ['#']
+            0?                    # [0]
+            (\d+\$?)?             # [width]
+            (\.(\d+\$?|\*)?)?     # ['.' precision]
+            (\?|{{identifier}})?  # [type]
+          )?
+        \}
+      scope: constant.other.placeholder.ron
+
   value:
     - include: constant
     - include: number
-    - include: raw_string
+    - include: format-raw-string
     - include: string
     - include: array
     - include: dictionary


### PR DESCRIPTION
Previous fix still didn't highlight `r` in `r#"` properly, so I've added a negative lookahead to `entity.name.tag.ron`
I think this isn't the proper solution as maybe it should have pushed a new syntax after `:` so that the pre-: rule doesn't override the post-: rule or something similar, but that would require a bit more refactoring effort

I've also copied the raw string rule from RustEnhanced that is a more appropriate matching rule that has the whole `r#"` instead of a single `r`, and it also includes literal escapes, but I don't know and **haven't checked** any **RON spec**, so not sure whether the raw strings are identical in Rust