### PR TITLE
upgrade to version 2

### DIFF
--- a/RON.sublime-syntax
+++ b/RON.sublime-syntax
@@ -3,6 +3,7 @@
 name: RON
 file_extensions:
   - ron
+version: 2
 scope: source.ron
 contexts:
   main:


### PR DESCRIPTION
allows user syntax override without editing the package itself (e.g., you could replace the raw syntax rule with your own easier)